### PR TITLE
ported library

### DIFF
--- a/shared/src/main/scala/minitest/api/Result.scala
+++ b/shared/src/main/scala/minitest/api/Result.scala
@@ -55,7 +55,7 @@ object Result {
     }
   }
 
-  final case class Failure(msg: String, source: Option[Throwable], location: Option[SourceLocation])
+  final case class Failure(msg: String | Null, source: Option[Throwable], location: Option[SourceLocation])
     extends Result[Nothing] {
 
     def formatted(name: String, withColors: Boolean): String =
@@ -69,7 +69,7 @@ object Result {
       val description = {
         val name = source.getClass.getName
         val className = name.substring(name.lastIndexOf(".") + 1)
-        Option(source.getMessage).filterNot(_.isEmpty)
+        Option(source.getMessage).filterNot(_.nn.isEmpty)
           .fold(className)(m => s"$className: $m")
       }
 
@@ -92,7 +92,7 @@ object Result {
       Result.Exception(other, None)
   }
 
-  private def formatError(name: String, msg: String,
+  private def formatError(name: String, msg: String | Null,
     source: Option[Throwable],
     location: Option[SourceLocation],
     traceLimit: Option[Int],

--- a/shared/src/main/scala/minitest/api/exceptions.scala
+++ b/shared/src/main/scala/minitest/api/exceptions.scala
@@ -19,10 +19,10 @@ package minitest.api
 
 import scala.util.control.NonFatal
 
-abstract class MiniTestException(message: String, cause: Throwable)
+abstract class MiniTestException(message: String | Null, cause: Throwable | Null)
   extends RuntimeException(message, cause)
 
-final class AssertionException(val message: String, val location: SourceLocation)
+final class AssertionException(val message: String | Null, val location: SourceLocation)
   extends MiniTestException(message, null)
 
 final class UnexpectedException(val reason: Throwable, val location: SourceLocation)

--- a/shared/src/main/scala/minitest/runner/ConsoleLogger.scala
+++ b/shared/src/main/scala/minitest/runner/ConsoleLogger.scala
@@ -25,14 +25,14 @@ final class ConsoleLogger extends Logger {
 
   def ansiCodesSupported(): Boolean =
     withColors
-  def error(msg: String): Unit =
+  def error(msg: String | Null): Unit =
     print(msg)
-  def warn(msg: String): Unit =
+  def warn(msg: String | Null): Unit =
     print(msg)
-  def info(msg: String): Unit =
+  def info(msg: String | Null): Unit =
     print(msg)
-  def debug(msg: String): Unit =
+  def debug(msg: String | Null): Unit =
     print(msg)
-  def trace(t: Throwable): Unit =
-    t.printStackTrace(System.out)
+  def trace(t: Throwable | Null): Unit =
+    t.nn.printStackTrace(System.out)
 }

--- a/shared/src/main/scala/minitest/runner/Framework.scala
+++ b/shared/src/main/scala/minitest/runner/Framework.scala
@@ -25,13 +25,15 @@ class Framework extends BaseFramework {
 
   def options: Options = Options()
 
-  def fingerprints(): Array[Fingerprint] =
+  // overriding method of type (): Array[sbt.testing.Fingerprint | JavaNull] | JavaNull
+  def fingerprints(): Array[Fingerprint | Null] =
     Array(ModuleFingerprint)
 
-  def runner(args: Array[String], remoteArgs: Array[String], testClassLoader: ClassLoader): Runner =
-    new minitest.runner.Runner(args, remoteArgs, options, testClassLoader)
+  def runner(args: Array[String | Null] | Null, remoteArgs: Array[String | Null] | Null, testClassLoader: ClassLoader | Null): Runner =
+    new minitest.runner.Runner(args, remoteArgs, options, testClassLoader.nn)
 
-  def slaveRunner(args: Array[String], remoteArgs: Array[String], testClassLoader: ClassLoader, send: String => Unit): Runner =
+  // overriding method of type Array[something | JavaNull] | JavaNull
+  def slaveRunner(args: Array[String | Null], remoteArgs: Array[String | Null], testClassLoader: ClassLoader, send: String => Unit): Runner =
     runner(args, remoteArgs, testClassLoader)
 }
 

--- a/shared/src/main/scala/minitest/runner/Runner.scala
+++ b/shared/src/main/scala/minitest/runner/Runner.scala
@@ -20,24 +20,25 @@ package minitest.runner
 import sbt.testing.{Runner => BaseRunner, Task => BaseTask, _}
 
 final class Runner(
-  val args: Array[String],
-  val remoteArgs: Array[String],
+  // error overiding Array[T | JavaNull] | JavaNull with Array[T]
+  val args: Array[String | Null] | Null,
+  val remoteArgs: Array[String | Null] | Null,
   val options: Options,
   classLoader: ClassLoader)
   extends BaseRunner {
 
   def done(): String = ""
 
-  def tasks(list: Array[TaskDef]): Array[BaseTask] = {
-    list.map(t => new Task(t, options, classLoader))
+  def tasks(list: Array[TaskDef | Null] | Null): Array[BaseTask | Null] = {
+    list.nn.map(t => new Task(t.nn, options, classLoader))
   }
 
   def receiveMessage(msg: String): Option[String] = {
     None
   }
 
-  def serializeTask(task: BaseTask, serializer: TaskDef => String): String =
-    serializer(task.taskDef())
+  def serializeTask(task: BaseTask, serializer: TaskDef | Null => String): String =
+    serializer(task.taskDef().nn)
 
   def deserializeTask(task: String, deserializer: String => TaskDef): BaseTask =
     new Task(deserializer(task), options, classLoader)


### PR DESCRIPTION
LOC changed: 30

**Requires fix to compiler** | 1
`Option(something nullable)` is `Option[something nullable]`; should be `Option[non-null]`.

**Nullable variable** | 4
Variables that really can be null and should therefore have a `|Null` type.

**External sbt library** | 7
I cannot find any documentation or source code for `sbt.testing.Task` and `sbt.testing.TaskDef`.
Usage of nn: 7

**Override java method** | 11
A Scala method overrides some Java method. We need to add `|Null` to the method's parameter types to make the override still work.

**Remove nullness from overridden java argument** | 2
We think the parameter will never be null. `.nn` as soon as we get the parameter.

